### PR TITLE
Refactored a few things + added blueprint 'events.yaml'

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -24,6 +24,13 @@ form:
         0: PLUGIN_ADMIN.DISABLED
       validate:
         type: bool
+    routes:
+      type: array
+      label: Routes
+      help: PLUGIN_SIMPLE_EVENTS.ROUTES
+      required: true
+      default: []
+      value_only: true
     delete_old:
       label: PLUGIN_SIMPLE_EVENTS.DELETE_OLD
       type: toggle

--- a/blueprints/events.yaml
+++ b/blueprints/events.yaml
@@ -1,0 +1,40 @@
+title: Terminen
+'@extends':
+    type: default
+    context: blueprints://pages
+
+form:
+  fields:
+    tabs:
+      type: tabs
+      active: 1
+
+      fields:
+        termin:
+          type: tab
+          title: Terminen
+
+          fields:
+            header.title:
+              type: text
+              label: PLUGIN_ADMIN.TITLE
+              validate:
+                required: true
+            header.content.order.by:
+              type: select
+              label: PLUGIN_SIMPLE_EVENTS.LABEL_ORDERBY
+              default: start
+              options:
+                start: PLUGIN_SIMPLE_EVENTS.OPTION_START
+                end: PLUGIN_SIMPLE_EVENTS.OPTION_END
+              validate:
+                type: string
+            header.content.order.dir:
+              type: select
+              label: PLUGIN_SIMPLE_EVENTS.LABEL_ORDERDIR
+              default: asc
+              options:
+                asc: PLUGIN_SIMPLE_EVENTS.OPTION_ASC
+                desc: PLUGIN_SIMPLE_EVENTS.OPTION_DESC
+              validate:
+                type: string

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,10 +1,16 @@
 en:
   PLUGIN_SIMPLE_EVENTS:
     ROUTES: Add routes on which Simple-Events should be activated
+    LABEL_ORDERBY: Order by
+    OPTION_START: Start day
+    OPTION_END: End day
+    LABEL_ORDERDIR: Direction
+    OPTION_ASC: Asc
+    OPTION_DESC: Desc
     DELETE_OLD: Delete past events automatically
     UNPUBLISH_DAY: On which day to unpublish an event
-    LABEL_START: start day
-    LABEL_END: end day (if given)
+    LABEL_START: Start day
+    LABEL_END: End day (if given)
     UNPUBLISH_TIME: At what time to unpublish an event
     USE_LOCATION: Show location field
     LABEL_LOCATION: Location
@@ -22,6 +28,12 @@ en:
 de:
   PLUGIN_SIMPLE_EVENTS:
     ROUTES: Fügen Sie Routen hinzu, auf denen Simple-Events aktiviert werden sollen
+    LABEL_ORDERBY: Sortieren nach
+    OPTION_START: Starttag
+    OPTION_END: Endtag
+    LABEL_END: Direction
+    OPTION_ASC: Aufsteigend
+    OPTION_DESC: Absteigend
     DELETE_OLD: Vergangene Termine automatisch löschen
     UNPUBLISH_DAY: An welchem Tag werden Termine aus der Liste genommen
     LABEL_START: Starttag

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,5 +1,6 @@
 en:
   PLUGIN_SIMPLE_EVENTS:
+    ROUTES: Add routes on which Simple-Events should be activated
     DELETE_OLD: Delete past events automatically
     UNPUBLISH_DAY: On which day to unpublish an event
     LABEL_START: start day
@@ -20,6 +21,7 @@ en:
 
 de:
   PLUGIN_SIMPLE_EVENTS:
+    ROUTES: Fügen Sie Routen hinzu, auf denen Simple-Events aktiviert werden sollen
     DELETE_OLD: Vergangene Termine automatisch löschen
     UNPUBLISH_DAY: An welchem Tag werden Termine aus der Liste genommen
     LABEL_START: Starttag

--- a/simple-events.php
+++ b/simple-events.php
@@ -41,6 +41,7 @@ class SimpleEventsPlugin extends Plugin
             $this->enable([
                 'onGetPageTemplates'   => ['onGetPageTemplates', 0],
                 'onGetPageBlueprints'   => ['onGetPageBlueprints', 0],
+                'onAdminSave'   => ['onAdminSave', 0],
             ]);
             return;
         }
@@ -80,6 +81,28 @@ class SimpleEventsPlugin extends Plugin
         $types->scanBlueprints('plugin://' . $this->name . '/blueprints');
     }
 
+    public function onAdminSave(Event $event) {
+        if (! $event['object'] instanceof Page || $event['object']->template() !== 'events') {
+            return;
+        }
+
+        $page = $event['object'];
+        $header = $page->header();
+        $orderBy = $header->content['order']['by'];
+        $orderDir= $header->content['order']['dir'];
+
+        $header->content = [
+            'items' => '@self.children',
+            'order' => [
+                'by' => $orderBy,
+                'dir' => $orderDir,
+            ],
+            'filter' => [
+                'published' => true,
+                'type' => 'event',
+            ],
+        ];
+    }
     /**
      * Add templates to twig paths.
      */

--- a/simple-events.yaml
+++ b/simple-events.yaml
@@ -1,4 +1,5 @@
 enabled: true
+routes: null
 delete_old: false
 unpublish_day: start
 unpublish_time: '00:00'


### PR DESCRIPTION
- Changed when event are being subscribed to
- Only subscribe to 'onPagesInitialized' when cache is being rebuild. Variables 'clearEvents' and 'checkunpublishDates' no longer needed.
- Added field 'routes' to config of plugin. Plugin should only add resources when current url is in list of routes.
- Added blueprint 'events.yaml':
  - To generate collection definition in page header
  - Allow user to choose 'order by' and 'order dir'

Cherry-pick anything you like and skip what you don't like. If you are happy with the way it is right now, just ignore this pull request... :-)